### PR TITLE
#2 Revoked babel auto updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,15 +32,15 @@
     "responsive"
   ],
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.49",
+    "@babel/runtime": "<=7.0.0-beta.49",
     "@flexis/srcset": "^1.0.1",
     "through2-concurrent": "^1.1.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0-beta.52",
-    "@babel/plugin-transform-runtime": "^7.0.0-beta.49",
-    "@babel/preset-env": "^7.0.0-beta.49",
-    "@babel/preset-stage-0": "^7.0.0-beta.49",
+    "@babel/core": "<=7.0.0-beta.52",
+    "@babel/plugin-transform-runtime": "<=7.0.0-beta.49",
+    "@babel/preset-env": "<=7.0.0-beta.49",
+    "@babel/preset-stage-0": "<=7.0.0-beta.49",
     "eslint": "^5.0.1",
     "eslint-config-trigen": "^3.2.0",
     "husky": "^1.0.0-rc.10",


### PR DESCRIPTION
Babel splitted the code from beta verion 56: https://github.com/babel/babel/commit/6695f5e2f7a2cfe49acfb63508dc4f1812185c7f#diff-a0a234e4064e6815dfc180424ff80914

This is kind of hotfix, that kills the issue just temporarily. To have a sustainable and stable solution the code base should be updated to the newest babel version `7.1.5`.